### PR TITLE
Use the artifactory API key as a password parameter rather than access-token.

### DIFF
--- a/tasks/expand_archive_posix.yml
+++ b/tasks/expand_archive_posix.yml
@@ -56,7 +56,7 @@
     --retries=100
     "--url={{ artifactory_base_url }}"
     "--user={{ ansible_deployment_artifactory_user }}"
-    "--access-token={{ ansible_deployment_artifactory_key }}"
+    "--password={{ ansible_deployment_artifactory_key }}"
     "{{ archive.artifactory_path | regex_replace('/$') }}/{{ archive.filename }}"
     "{{ artifactory_downloads_directory }}/{{ archive.filename }}"
   environment:

--- a/tasks/expand_archive_windows.yml
+++ b/tasks/expand_archive_windows.yml
@@ -64,7 +64,7 @@
     --retries=100
     "--url={{ artifactory_base_url }}"
     "--user={{ ansible_deployment_artifactory_user }}"
-    "--access-token={{ ansible_deployment_artifactory_key }}"
+    "--password={{ ansible_deployment_artifactory_key }}"
     "{{ archive.artifactory_path | regex_replace('/$') }}/{{ archive.filename }}"
     "{{ artifactory_downloads_directory }}/{{ archive.filename }}"
   when: >


### PR DESCRIPTION
See https://github.com/jfrog/jfrog-cli/issues/1814 for discussion. (NO_JIRA)

I made this change locally and it allowed me to provision databases for my linux build machine.
The discussion in that thread seems to indicate that this is just a problem with version 2.33 of the jfrog API, but that this is the correct fix in the long term anyway.