### PR TITLE
Add variable for the JFrog CLI command (NO_JIRA)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ base_artifactory_archive_directory: "{{ platform_specific_default_base_artifacto
 artifactory_status_directory: "{{ base_artifactory_archive_directory }}/status/"
 artifactory_downloads_directory: "{{ base_artifactory_archive_directory }}/downloads/"
 artifactory_tempdownloads_directory: "{{ base_artifactory_archive_directory }}/tmpdownloads/"
+jfrog_cli_command: "jfrog"

--- a/tasks/expand_archive_posix.yml
+++ b/tasks/expand_archive_posix.yml
@@ -50,7 +50,7 @@
 
 - name: "{{ archive.filename }}: Download file if sha256 changed or destination directory is new"
   ansible.builtin.shell: >
-    jfrog rt dl
+    {{ jfrog_cli_command }} rt dl
     --flat
     --fail-no-op
     --retries=100

--- a/tasks/expand_archive_windows.yml
+++ b/tasks/expand_archive_windows.yml
@@ -58,7 +58,7 @@
     $env:CI = 'true';
     $env:JFROG_CLI_OFFER_CONFIG = 'false';
     $env:JFROG_CLI_TEMP_DIR = "{{ artifactory_tempdownloads_directory }}";
-    jfrog rt dl
+    {{ jfrog_cli_command }} rt dl
     --flat
     --fail-no-op
     --retries=100


### PR DESCRIPTION
The JFrog CLI application is transitioning to using `jf` rather than `jfrog` as its executable name. This will make it possible to switch the name depending on which version is installed on the target host.