### PR TITLE
Ensure extraction destination permissions are correct after extracting (NO_JIRA)

### DIFF
--- a/tasks/expand_archive_posix.yml
+++ b/tasks/expand_archive_posix.yml
@@ -163,6 +163,14 @@
     recurse: true
   become: true
 
+- name: "{{ archive.filename }}: Ensure correct permissions on destination directory"  # noqa: name[template]
+  ansible.builtin.file:
+    dest: "{{ archive.base_destination_directory }}"
+    state: directory
+    owner: "{{ archive.contents_owner | default(ansible_user) }}"
+    mode: "0755"
+  become: true
+
 - name: "{{ archive.filename }}: Write sha256 file"  # noqa: name[template]
   ansible.builtin.copy:
     dest: "{{ artifactory_status_directory }}/{{ archive.filename }}.sha256"


### PR DESCRIPTION
As we now default to setting permissions on extracted non-tar archives to 0644 we need to afterwards ensure separately that the destination directory is set to 0755, as the file permission setting task will set them to 0644 which results in permission denied errors when trying to list it (even though the owner is correct).