### PR TITLE
Add +x to subdirectories of archives too

### DIFF
--- a/tasks/expand_archive_posix.yml
+++ b/tasks/expand_archive_posix.yml
@@ -163,13 +163,23 @@
     recurse: true
   become: true
 
-- name: "{{ archive.filename }}: Ensure correct permissions on destination directory"  # noqa: name[template]
+- name: Gather list of all directories in {{ archive.base_destination_directory }}
+  ansible.builtin.find:
+    paths: "{{ archive.base_destination_directory }}"
+    file_type: directory
+    recurse: true
+  register: permission_directories
+
+- name: "{{ archive.filename }}: Ensure correct permissions on destination directories"  # noqa: name[template]
   ansible.builtin.file:
-    dest: "{{ archive.base_destination_directory }}"
+    dest: "{{ directory.path }}"
     state: directory
     owner: "{{ archive.contents_owner | default(ansible_user) }}"
     mode: "0755"
   become: true
+  loop: permission_directories
+  loop_control:
+    loop_var: directory
 
 - name: "{{ archive.filename }}: Write sha256 file"  # noqa: name[template]
   ansible.builtin.copy:

--- a/tasks/expand_archive_posix.yml
+++ b/tasks/expand_archive_posix.yml
@@ -177,7 +177,7 @@
     owner: "{{ archive.contents_owner | default(ansible_user) }}"
     mode: "0755"
   become: true
-  loop: permission_directories
+  loop: "{{ permission_directories }}"
   loop_control:
     loop_var: directory
 

--- a/tasks/expand_archive_posix.yml
+++ b/tasks/expand_archive_posix.yml
@@ -168,6 +168,7 @@
     paths: "{{ archive.base_destination_directory }}"
     file_type: directory
     recurse: true
+  become: true
   register: permission_directories
 
 - name: "{{ archive.filename }}: Ensure correct permissions on destination directories"  # noqa: name[template]
@@ -177,7 +178,7 @@
     owner: "{{ archive.contents_owner | default(ansible_user) }}"
     mode: "0755"
   become: true
-  loop: "{{ permission_directories }}"
+  loop: "{{ permission_directories.files }}"
   loop_control:
     loop_var: directory
 

--- a/tasks/expand_archive_posix.yml
+++ b/tasks/expand_archive_posix.yml
@@ -163,6 +163,19 @@
     recurse: true
   become: true
 
+- name: "{{ archive.filename }}: Ensure correct owner on destination directory"  # noqa: name[template]
+  ansible.builtin.file:
+    owner: "{{ archive.contents_owner | default(ansible_user) }}"
+    dest: "{{ archive.base_destination_directory }}"
+  become: true
+
+- name: "{{ archive.filename }}: Ensure correct permissions on destination directory"  # noqa: name[template]
+  ansible.builtin.file:
+    dest: "{{ archive.base_destination_directory }}"
+    state: directory
+    mode: "0755"
+  become: true
+
 - name: Gather list of all directories in {{ archive.base_destination_directory }}
   ansible.builtin.find:
     paths: "{{ archive.base_destination_directory }}"


### PR DESCRIPTION
The previous change only sets mode `0755` on the main output directory, which means the permissions on eg. the `csd/subsets/` directory or the Mogul data subdirectories were still broken and could not be listed. This will make sure all subdirectories in the main destination are set to `0755`.