### PR TITLE
Include default Homebrew prefix (NO_JIRA)

### DIFF
--- a/tasks/expand_archive_posix.yml
+++ b/tasks/expand_archive_posix.yml
@@ -61,7 +61,7 @@
     "{{ archive.artifactory_path | regex_replace('/$') }}/{{ archive.filename }}"
     "{{ artifactory_downloads_directory }}/{{ archive.filename }}"
   environment:
-    PATH: "/usr/local/bin:/usr/bin"
+    PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin"
     CI: "true"
     JFROG_CLI_OFFER_CONFIG: "false"
     JFROG_CLI_TEMP_DIR: "{{ artifactory_tempdownloads_directory }}"


### PR DESCRIPTION
This is required on ARM macOS, where Homebrew cannot install to `/usr/local/` and instead has to live in `/opt/homebrew`.